### PR TITLE
Remove full connection string from log messages

### DIFF
--- a/src/Libraries/MySql.cs
+++ b/src/Libraries/MySql.cs
@@ -234,7 +234,7 @@ namespace Oxide.Core.MySql.Libraries
             Connection connection;
             if (connections.TryGetValue(conStr, out connection))
             {
-                Interface.Oxide.LogWarning("Already open connection ({0}), using existing instead...", connection.Con?.ConnectionString);
+                Interface.Oxide.LogWarning("There is already an open connection, using existing connection instead...");
             }
             else
             {

--- a/src/Libraries/MySql.cs
+++ b/src/Libraries/MySql.cs
@@ -267,7 +267,7 @@ namespace Oxide.Core.MySql.Libraries
 
                     if (connection.Value.Con?.State != ConnectionState.Closed)
                     {
-                        Interface.Oxide.LogWarning("Unclosed mysql connection ({0}), by plugin '{1}', closing...", connection.Value.Con?.ConnectionString, connection.Value.Plugin?.Name ?? "null");
+                        Interface.Oxide.LogWarning("Unclosed MySQL connection from plugin '{1}', closing...", sender.Name);
                     }
 
                     connection.Value.Con?.Close();


### PR DESCRIPTION
Fixes the issue raised in [this forum post](https://umod.org/community/rust/46503-sql-connection-string-printed-in-console-when-a-connection-is-opened) and also makes the message a proper sentence to improve readability.