### PR TITLE
Add support for mariaDB version 10.10 and later. 

### DIFF
--- a/src/Libraries/Interceptor.cs
+++ b/src/Libraries/Interceptor.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Data;
+using MySql.Data.MySqlClient;
+
+namespace CommandApp
+{
+	/// <summary>
+	/// Filters out collations with NULL id (e.g. UCA-14.0.0) from SHOW COLLATION command
+    /// Credit to Jeffraska 
+    ///    https://github.com/jeffraska/Jf.MySql.Data.Collations
+	/// </summary>
+	public sealed class Interceptor : BaseCommandInterceptor
+    {
+		public override bool ExecuteReader(string sql, CommandBehavior behavior, ref MySqlDataReader returnValue)
+		{
+            if (!sql.Equals("SHOW COLLATION", StringComparison.OrdinalIgnoreCase))
+			{
+                return false;
+			}
+
+			using var command = ActiveConnection.CreateCommand();
+			command.CommandText = "SHOW COLLATION WHERE id IS NOT NULL";
+			returnValue = command.ExecuteReader(behavior);
+			return true;
+		}
+	}
+}

--- a/src/Libraries/MySql.cs
+++ b/src/Libraries/MySql.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
+using CommandApp;
 
 namespace Oxide.Core.MySql.Libraries
 {
@@ -220,7 +221,9 @@ namespace Oxide.Core.MySql.Libraries
         [LibraryFunction("OpenDb")]
         public Connection OpenDb(string host, int port, string database, string user, string password, Plugin plugin, bool persistent = false)
         {
-            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;default command timeout=120;Allow Zero Datetime=true;", plugin, persistent);
+            string interceptor = "CommandApp.Interceptor," + typeof(CommandApp.Interceptor).Assembly.FullName;
+            Utf8mb3.Enable();
+            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;default command timeout=120;Allow Zero Datetime=true;commandinterceptors={interceptor};", plugin, persistent);
         }
 
         public Connection OpenDb(string conStr, Plugin plugin, bool persistent = false)

--- a/src/Libraries/MySql.cs
+++ b/src/Libraries/MySql.cs
@@ -221,13 +221,13 @@ namespace Oxide.Core.MySql.Libraries
         [LibraryFunction("OpenDb")]
         public Connection OpenDb(string host, int port, string database, string user, string password, Plugin plugin, bool persistent = false)
         {
-            string interceptor = "CommandApp.Interceptor," + typeof(CommandApp.Interceptor).Assembly.FullName;
-            Utf8mb3.Enable();
-            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;default command timeout=120;Allow Zero Datetime=true;commandinterceptors={interceptor};", plugin, persistent);
+            return OpenDb($"Server={host};Port={port};Database={database};User={user};Password={password};Pooling=false;default command timeout=120;Allow Zero Datetime=true;", plugin, persistent);
         }
 
         public Connection OpenDb(string conStr, Plugin plugin, bool persistent = false)
         {
+            Utf8mb3.Enable();
+            conStr += ";commandinterceptors=CommandApp.Interceptor," + typeof(CommandApp.Interceptor).Assembly.FullName;
             Dictionary<string, Connection> connections;
             if (!_connections.TryGetValue(plugin?.Name ?? "null", out connections))
             {

--- a/src/Libraries/Utf8mb3.cs
+++ b/src/Libraries/Utf8mb3.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections;
+using MySql.Data.MySqlClient;
+
+namespace CommandApp
+{
+    // ReSharper disable once InconsistentNaming
+    /// Credit to Jeffraska 
+    ///    https://github.com/jeffraska/Jf.MySql.Data.Collations
+    ///    
+    public static class Utf8mb3
+	{
+		private static readonly Version NewFieldNamingVersion = new Version(6, 10, 0);
+		
+		public static void Enable()
+		{
+			// Add internal mapping of database utf8mb3 charset to .NET framework's UTF-8 encoding
+			var assembly = System.Reflection.Assembly.GetAssembly(typeof(MySqlConnection));
+			var connectorVersion = assembly.GetName().Version;
+			
+			var mappingFieldName = connectorVersion >= NewFieldNamingVersion ? "_mapping" : "mapping";
+			
+			var mappingField = assembly
+				.GetType("MySql.Data.MySqlClient.CharSetMap").GetField(mappingFieldName,
+					System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.GetField |
+					System.Reflection.BindingFlags.Static);
+
+			if (mappingField != null)
+			{
+				var mappingDictionary = (IDictionary)mappingField.GetValue(null);
+				var utf8Mapping = mappingDictionary["utf8"];
+
+				if (utf8Mapping != null)
+				{
+					try
+					{
+						mappingDictionary.Add("utf8mb3", utf8Mapping);
+                        mappingDictionary.Add("utf8mb4", utf8Mapping);
+                    }
+					catch (ArgumentException)
+					{
+						// Item already exist
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Libraries/Utf8mb3.cs
+++ b/src/Libraries/Utf8mb3.cs
@@ -10,7 +10,9 @@ namespace CommandApp
     ///    
     public static class Utf8mb3
 	{
-		private static readonly Version NewFieldNamingVersion = new Version(6, 10, 0);
+        // verified that starting version 6.10.0,  CharSetMap.mapping was changed to CharSetMap._mapping
+        // code will still work if MySql.Data.dll is upgraded
+        private static readonly Version NewFieldNamingVersion = new Version(6, 10, 0);
 		
 		public static void Enable()
 		{
@@ -35,6 +37,7 @@ namespace CommandApp
 					try
 					{
 						mappingDictionary.Add("utf8mb3", utf8Mapping);
+                        mappingDictionary.Add("utf8mb4", utf8Mapping);
                     }
 					catch (ArgumentException)
 					{

--- a/src/Libraries/Utf8mb3.cs
+++ b/src/Libraries/Utf8mb3.cs
@@ -37,7 +37,6 @@ namespace CommandApp
 					try
 					{
 						mappingDictionary.Add("utf8mb3", utf8Mapping);
-                        mappingDictionary.Add("utf8mb4", utf8Mapping);
                     }
 					catch (ArgumentException)
 					{

--- a/src/Libraries/Utf8mb3.cs
+++ b/src/Libraries/Utf8mb3.cs
@@ -35,7 +35,6 @@ namespace CommandApp
 					try
 					{
 						mappingDictionary.Add("utf8mb3", utf8Mapping);
-                        mappingDictionary.Add("utf8mb4", utf8Mapping);
                     }
 					catch (ArgumentException)
 					{

--- a/src/Oxide.MySql.csproj
+++ b/src/Oxide.MySql.csproj
@@ -16,6 +16,9 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Oxide.Core" Version="2.0.*" />
     <Reference Include="MySql.Data">


### PR DESCRIPTION
Add support for MariaDB version 10.10 and later. should not affect older version of MariaDB or MySql

add commandinterceptors to remove DBnull errors on MariaDB >= 10.10.  no impact on version before 10.10
append 'utf8mb3' and 'utf8mb4' charset to MySql.Data's internal mapping Dictionary
add <LangVersion>9.0</LangVersion>  in csproj file

Tested with plugin MySqlWhitelist and KillRecords

SQL version tested:
mariadb-11.5.2
mariadb-10.10.7
mariadb-10.9.8
mariadb-10.6.20

mysql-5.7.44
mysql-8.0.40    MySqlException: Authentication method 'caching_sha2_password' not supported by any of the available plugins. There is another PR for that
